### PR TITLE
In rotate_x, use argument rather than uniform.

### DIFF
--- a/view-frustum-rotation.v.glsl
+++ b/view-frustum-rotation.v.glsl
@@ -45,8 +45,8 @@ mat4 rotate_x(float theta)
 {
     return mat4(
         vec4(1.0,         0.0,         0.0, 0.0),
-        vec4(0.0,  cos(timer),  sin(timer), 0.0),
-        vec4(0.0, -sin(timer),  cos(timer), 0.0),
+        vec4(0.0,  cos(theta),  sin(theta), 0.0),
+        vec4(0.0, -sin(theta),  cos(theta), 0.0),
         vec4(0.0,         0.0,         0.0, 1.0)
     );
 }


### PR DESCRIPTION
I believe the original was a mistake introduced when the function was updated to take an argument. The mistake [appears on the website](http://duriansoftware.com/joe/An-intro-to-modern-OpenGL.-Chapter-3:-3D-transformation-and-projection.html) as well.
